### PR TITLE
Adjust initial window size to match reference screenshot

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -278,8 +278,8 @@ class CoordinateApp:
         self.page.title = "Coordinate Converter"
         self.page.padding = 16
         self.page.theme_mode = ft.ThemeMode.SYSTEM
-        self.page.window_width = 1280
-        self.page.window_height = 900
+        self.page.window_width = 1998
+        self.page.window_height = 1606
         self.page.on_keyboard_event = self._on_page_key
         self.input_tab_order: List[str] = (
             []


### PR DESCRIPTION
## Summary
- update the Flet desktop window defaults to 1998×1606 so the application opens at the size shown in the provided screenshot

## Testing
- pytest *(fails: test_app_initialization_with_map expects an http://localhost map URL but receives a data:text/html payload)*

------
https://chatgpt.com/codex/tasks/task_e_68debe90eba483299f3e96fddf1b0a97