### PR TITLE
Inline Leaflet map content for double-click capture

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
@@ -379,7 +378,6 @@ class CoordinateApp:
                 "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                 tile_url,
             )
-        # Use base64 encoding for better compatibility
         import base64
 
         map_html_b64 = base64.b64encode(map_html_content.encode("utf-8")).decode(
@@ -802,14 +800,38 @@ class CoordinateApp:
                 "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
                 tile_url,
             )
-        return f"data:text/html,{urllib.parse.quote(inline_html)}"
+        import base64
+
+        encoded = base64.b64encode(inline_html.encode("utf-8")).decode("ascii")
+        return f"data:text/html;base64,{encoded}"
+
+    def _invoke_map_js(self, script: str) -> bool:
+        executed = False
+        if hasattr(self.map_view, "run_javascript"):
+            try:
+                self.map_view.run_javascript(script)
+                executed = True
+            except Exception as exc:  # pragma: no cover - logging only
+                print(f"[MAP] Error executing script via run_javascript: {exc}")
+                import traceback
+
+                traceback.print_exc()
+        if not executed and hasattr(self.map_view, "eval_js"):
+            try:
+                self.map_view.eval_js(script)
+                executed = True
+            except Exception as exc:  # pragma: no cover - logging only
+                print(f"[MAP] Error executing script via eval_js: {exc}")
+                import traceback
+
+                traceback.print_exc()
+        return executed
 
     def _handle_map_page_event(self, _event) -> None:
         print("[MAP] Page loaded, map is ready")
         self.map_ready = True
         # Ensure default map type is applied
-        if hasattr(self.map_view, "run_javascript"):
-            self.map_view.run_javascript("changeMapType('terrain');")
+        self._invoke_map_js("changeMapType('terrain');")
         if self.current_results.get("WGS84_GEO"):
             lat, lon, *_ = self.current_results["WGS84_GEO"]
             self._update_map(lat, lon)
@@ -817,8 +839,11 @@ class CoordinateApp:
     def _update_map(self, lat: float, lon: float) -> None:
         if not self.map_ready:
             return
-        if hasattr(self.map_view, "run_javascript"):
-            self.map_view.run_javascript(f"updateMapCenter({lat}, {lon});")
+        command = f"updateMapCenter({lat}, {lon});"
+        if not self._invoke_map_js(command):
+            print(
+                f"[MAP] Unable to execute map update script. Available methods: {[m for m in dir(self.map_view) if 'java' in m.lower() or 'eval' in m.lower()]}"
+            )
 
     def _format_latlon(self, lat: float, lon: float, fmt: str) -> str:
         if fmt == "DDM":
@@ -1349,56 +1374,46 @@ class CoordinateApp:
             f"[MAP] Attempting to change map type to: {map_type}, map_ready={self.map_ready}"
         )
 
-        # Use run_javascript method (not eval_js)
-        if hasattr(self.map_view, "run_javascript"):
-            try:
-                self.map_view.run_javascript(f"changeMapType('{map_type}');")
-                print(f"[MAP] Successfully sent changeMapType command for {map_type}")
-            except Exception as e:
-                print(f"[MAP] Error changing map type: {e}")
-                import traceback
-
-                traceback.print_exc()
+        command = f"changeMapType('{map_type}');"
+        if self._invoke_map_js(command):
+            print(f"[MAP] Successfully sent changeMapType command for {map_type}")
         else:
             print(
-                f"[MAP] WebView does not have run_javascript method. Available: {[m for m in dir(self.map_view) if 'java' in m.lower()]}"
+                "[MAP] WebView does not have a JavaScript execution method. Available: "
+                f"{[m for m in dir(self.map_view) if 'java' in m.lower() or 'eval' in m.lower()]}"
             )
 
     def _set_input_coordinate_from_latlon(self, lat: float, lon: float) -> None:
-        # Ensure input type supports lat/lon without changing type
-        if self.input_coord_selector.value not in {
-            "WGS84_GEO_DD",
-            "SWEREF99_GEO_DD",
-            "WGS84_GEO_DDM",
-            "WGS84_GEO_DMS",
-            "SWEREF99_GEO_DDM",
-            "SWEREF99_GEO_DMS",
-            "FREE_TEXT",
-        }:
+        option = COORDINATE_OPTIONS.get(self.input_coord_selector.value)
+        if option is None:
             return
-        # Set values and trigger conversion
-        lat_field = self.input_fields.get("lat_deg")
-        lon_field = self.input_fields.get("lon_deg")
-        lat_dir_field = self.input_fields.get("lat_dir")
-        lon_dir_field = self.input_fields.get("lon_dir")
-        if self.input_coord_selector.value == "FREE_TEXT":
-            # Populate free text directly in DD (lat lon)
+
+        parsed = ParsedCoordinate(
+            crs=CRSCode.WGS84_GEO,
+            values=(lat, lon),
+            source_format="DD",
+            height=None,
+            height_system=self.input_height_selector.value,
+        )
+
+        self._run_conversion(parsed)
+
+        if option.key == "FREE_TEXT":
             text_field = self.input_fields.get("text")
             if text_field is not None:
-                text_field.value = f"{lat} {lon}"
-                self._on_convert(None)
+                self._suspend_input_events = True
+                try:
+                    text_field.value = f"{lat:.6f} {lon:.6f}"
+                finally:
+                    self._suspend_input_events = False
+            self.page.update()
             return
-        if (
-            lat_field is not None
-            and lon_field is not None
-            and lat_dir_field is not None
-            and lon_dir_field is not None
-        ):
-            lat_dir_field.value = "N" if lat >= 0 else "S"
-            lon_dir_field.value = "E" if lon >= 0 else "W"
-            lat_field.value = f"{abs(lat):.6f}"
-            lon_field.value = f"{abs(lon):.6f}"
-            self._on_convert(None)
+
+        if not self.current_results:
+            return
+
+        self._populate_input_from_results(option)
+        self.page.update()
 
 
 def main(page: ft.Page) -> None:

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -385,6 +385,7 @@ class CoordinateApp:
         )
         map_url = f"data:text/html;base64,{map_html_b64}"
         self.map_ready = False
+        self._suppress_map_update = False
 
         def on_console_message(e):
             try:
@@ -837,7 +838,7 @@ class CoordinateApp:
             self._update_map(lat, lon)
 
     def _update_map(self, lat: float, lon: float) -> None:
-        if not self.map_ready:
+        if not self.map_ready or self._suppress_map_update:
             return
         command = f"updateMapCenter({lat}, {lon});"
         if not self._invoke_map_js(command):
@@ -1396,7 +1397,11 @@ class CoordinateApp:
             height_system=self.input_height_selector.value,
         )
 
-        self._run_conversion(parsed)
+        self._suppress_map_update = True
+        try:
+            self._run_conversion(parsed)
+        finally:
+            self._suppress_map_update = False
 
         if option.key == "FREE_TEXT":
             text_field = self.input_fields.get("text")

--- a/src/app/map_view/leaflet.html
+++ b/src/app/map_view/leaflet.html
@@ -15,7 +15,7 @@
     <div id="map"></div>
     <script>
         // Initialize map
-        var map = L.map('map').setView([59.3293, 18.0686], 10);
+        var map = L.map('map', { doubleClickZoom: false }).setView([59.3293, 18.0686], 10);
         
         // Map type configurations per UI specification
         var mapTypes = {

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -22,10 +22,11 @@ def test_app_initialization_with_map():
     # Verify map view was created
     assert app.map_view is not None, "Map view was not created"
     
-    # Verify map URL is an http://localhost URL using embedded server
+    # Verify map URL is provided as an inline base64 data URL
     map_url = app._map_url()
-    assert map_url.startswith("http://localhost:"), f"Map URL should start with http://localhost:, got: {map_url}"
-    assert "leaflet.html" in map_url, f"Map URL should contain leaflet.html, got: {map_url}"
+    assert map_url.startswith(
+        "data:text/html;base64,"
+    ), f"Map URL should be a base64 data URL, got: {map_url}"
     
     print(f"✓ App initialized successfully")
     print(f"  Map URL: {map_url}")
@@ -45,11 +46,9 @@ def test_map_view_properties():
     # Check that map view has expand property
     assert app.map_view.expand is True, "Map view should have expand=True"
     
-    # Check that map view URL is localhost (embedded server)
-    assert app.map_view.url.startswith("http://localhost:"), \
-        f"Map view URL should use localhost server, got: {app.map_view.url}"
-    assert "leaflet.html" in app.map_view.url, \
-        f"Map view URL should contain leaflet.html, got: {app.map_view.url}"
+    # Check that map view URL uses inline data URL
+    assert app.map_view.url.startswith("data:text/html;base64,"), \
+        f"Map view URL should be a base64 data URL, got: {app.map_view.url}"
     
     print(f"✓ Map view properties are correct")
 

--- a/tests/test_app_integration.py
+++ b/tests/test_app_integration.py
@@ -109,7 +109,7 @@ def test_map_center_update():
 def test_map_update_before_ready():
     """Test that map update is safe when map is not ready."""
     from app import main
-    
+
     mock_page = mock.MagicMock()
     mock_page.window_width = 1200
     mock_page.window_height = 800
@@ -131,10 +131,34 @@ def test_map_update_before_ready():
     print(f"✓ Map update is safely skipped when map is not ready")
 
 
+def test_double_click_capture_does_not_pan_map():
+    """Double-click capture should not trigger a map pan."""
+    from app import main
+
+    mock_page = mock.MagicMock()
+    mock_page.window_width = 1200
+    mock_page.window_height = 800
+
+    app = main.CoordinateApp(mock_page)
+
+    app.map_ready = True
+    app._invoke_map_js = mock.MagicMock(return_value=True)
+
+    app._set_input_coordinate_from_latlon(10.0, 20.0)
+
+    app._invoke_map_js.assert_not_called()
+
+    app._update_map(11.0, 22.0)
+
+    app._invoke_map_js.assert_called_once()
+
+    print("✓ Map stays put when capturing coordinates from double-click")
+
+
 def test_webview_deprecation_notice():
     """Display information about WebView deprecation."""
     import flet as ft
-    
+
     # Check if flet-webview is available
     try:
         import flet_webview


### PR DESCRIPTION
## Summary
- load the Leaflet map via a base64 data URL so no local HTTP server is required
- keep JavaScript wiring for double-click capture while preserving tile URL override support
- update integration tests to match the inline map delivery approach

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68debf0a98948329900d375f184f629d