### PR TITLE
Fix MGRS accuracy label refresh

### DIFF
--- a/tests/test_mgrs_accuracy.py
+++ b/tests/test_mgrs_accuracy.py
@@ -1,0 +1,67 @@
+"""Tests for MGRS accuracy labels."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+
+def _make_app():
+    from app import main
+
+    page = mock.MagicMock()
+    page.window_width = 1200
+    page.window_height = 800
+    return main.CoordinateApp(page)
+
+
+def _set_mgrs_value(app, value: str) -> None:
+    app.input_coord_selector.value = "MGRS"
+    app._rebuild_input_fields()
+    app.input_fields["mgrs"].value = value
+
+
+def test_mgrs_accuracy_for_all_supported_precisions():
+    app = _make_app()
+
+    cases = [
+        ("33UXP", "±100000 m"),
+        ("33UXP04", "±10000 m"),
+        ("33UXP0481", "±1000 m"),
+        ("33UXP048114", "±100 m"),
+        ("33UXP04811421", "±10 m"),
+        ("33UXP0481142198", "±1 m"),
+    ]
+
+    for value, expected in cases:
+        _set_mgrs_value(app, value)
+        assert app._accuracy_for_mgrs_field() == expected
+
+
+def test_mgrs_accuracy_hidden_for_invalid_values():
+    app = _make_app()
+
+    invalid_values = [
+        "",  # empty
+        "  ",  # whitespace
+        "33",  # missing grid letters
+        "33UAA1",  # odd number of digits
+        "33UXP000000000000",  # too many digits
+        "33UX?0481",  # illegal character
+    ]
+
+    for value in invalid_values:
+        _set_mgrs_value(app, value)
+        assert app._accuracy_for_mgrs_field() is None
+
+
+def test_mgrs_accuracy_label_updates_when_results_populate_field():
+    app = _make_app()
+    app.current_results = {"MGRS": "33VXG5085729033"}
+    app.input_coord_selector.value = "MGRS"
+
+    app._rebuild_input_fields()
+
+    accuracy_label = app._field_accuracy_labels.get("mgrs")
+    assert accuracy_label is not None
+    assert accuracy_label.value == "±1 m"
+    assert accuracy_label.visible is True


### PR DESCRIPTION
## Summary
- add a regression test that exercises every supported MGRS precision and checks the derived ±cm/m label
- ensure invalid or incomplete MGRS strings keep the accuracy label hidden
- refresh the MGRS accuracy label when results populate the input field so precision stays visible

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dece64535c8329ae1e16fc2280be90